### PR TITLE
feat: rename module name

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "trim": "cd deps/ && rm -rf libbson/.git && rm -rf libshmcache/.git && rm -rf libfastcommon/.git && rm libbson/.gitignore && rm libbson/README && cp libbson/README.rst libbson/README"
   },
   "binary": {
-    "module_name": "NativeExtension",
+    "module_name": "shm-cache",
     "module_path": "./binding",
     "host": "https://github.com/denghongcai/node-shm-cache/releases/download/",
     "remote_path": "{version}"


### PR DESCRIPTION
rename module name, so that we can use a mirror
https://github.com/mapbox/node-pre-gyp#download-binary-files-from-a-mirror